### PR TITLE
Qudi.Visualizerのグラフ構築をQudi.Coreへ移植し、Core側テストを追加

### DIFF
--- a/src/Qudi.Core/QudiVisualizationGraphModel.cs
+++ b/src/Qudi.Core/QudiVisualizationGraphModel.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+
+namespace Qudi;
+
+/// <summary>
+/// A node in the dependency graph.
+/// </summary>
+public sealed record QudiVisualizationNode(
+    string Id,
+    string Label,
+    string Kind,
+    bool IsConditionMatched = true,
+    bool IsExternal = false,
+    bool IsInterface = false
+);
+
+/// <summary>
+/// An edge in the dependency graph.
+/// </summary>
+public sealed record QudiVisualizationEdge(
+    string From,
+    string To,
+    string Kind,
+    string? Condition = null,
+    string? Key = null,
+    int Order = 0
+);
+
+/// <summary>
+/// Dependency graph for registered services.
+/// </summary>
+public sealed record QudiVisualizationGraph(
+    IReadOnlyList<QudiVisualizationNode> Nodes,
+    IReadOnlyList<QudiVisualizationEdge> Edges
+);

--- a/src/Qudi.Visualizer/GlobalUsings.cs
+++ b/src/Qudi.Visualizer/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Qudi;

--- a/src/Qudi.Visualizer/QudiVisualizationModel.cs
+++ b/src/Qudi.Visualizer/QudiVisualizationModel.cs
@@ -64,29 +64,6 @@ internal sealed record QudiVisualizationReport(
     [property: JsonIgnore] IReadOnlyList<Type> ExportedTypes
 );
 
-internal sealed record QudiVisualizationNode(
-    string Id,
-    string Label,
-    string Kind,
-    bool IsConditionMatched = true,
-    bool IsExternal = false,
-    bool IsInterface = false
-);
-
-internal sealed record QudiVisualizationEdge(
-    string From,
-    string To,
-    string Kind,
-    string? Condition = null,
-    string? Key = null,
-    int Order = 0
-);
-
-internal sealed record QudiVisualizationGraph(
-    IReadOnlyList<QudiVisualizationNode> Nodes,
-    IReadOnlyList<QudiVisualizationEdge> Edges
-);
-
 internal sealed record VisualizationContext(
     QudiConfiguration Configuration,
     IReadOnlyList<RegistrationView> Applicable,

--- a/tests/Qudi.Tests/VisualizationGraphBuilderTests.cs
+++ b/tests/Qudi.Tests/VisualizationGraphBuilderTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Linq;
+using TUnit;
+
+namespace Qudi.Tests;
+
+public sealed class VisualizationGraphBuilderTests
+{
+    [Test]
+    public void Build_CreatesRegistrationAndDependencyEdges()
+    {
+        var configuration = CreateConfiguration();
+
+        var graph = QudiVisualizationGraphBuilder.Build(configuration);
+
+        graph.Nodes.Any(n => n.Label == nameof(IRootService) && n.Kind == "service").ShouldBeTrue();
+        graph.Nodes.Any(n => n.Label == nameof(RootService) && n.Kind == "implementation").ShouldBeTrue();
+        graph.Nodes.Any(n => n.Label == nameof(IDependency) && n.Kind == "service").ShouldBeTrue();
+
+        graph
+            .Edges.Any(e =>
+                e.Kind == "registration"
+                && graph.Nodes.Any(n => n.Id == e.From && n.Label == nameof(IRootService))
+                && graph.Nodes.Any(n => n.Id == e.To && n.Label == nameof(RootService))
+            )
+            .ShouldBeTrue();
+
+        graph
+            .Edges.Any(e =>
+                e.Kind == "dependency"
+                && graph.Nodes.Any(n => n.Id == e.From && n.Label == nameof(RootService))
+                && graph.Nodes.Any(n => n.Id == e.To && n.Label == nameof(IDependency))
+            )
+            .ShouldBeTrue();
+    }
+
+    [Test]
+    public void BuildFromRoot_ReturnsOnlyReachableNodes()
+    {
+        var configuration = CreateConfiguration();
+
+        var graph = QudiVisualizationGraphBuilder.BuildFromRoot(configuration, typeof(IRootService));
+
+        graph.Nodes.Any(n => n.Label == nameof(IRootService)).ShouldBeTrue();
+        graph.Nodes.Any(n => n.Label == nameof(RootService)).ShouldBeTrue();
+        graph.Nodes.Any(n => n.Label == nameof(IDependency)).ShouldBeTrue();
+        graph.Nodes.Any(n => n.Label == nameof(UnusedService)).ShouldBeFalse();
+    }
+
+    private static QudiConfiguration CreateConfiguration()
+    {
+        var registrations = new TypeRegistrationInfo[]
+        {
+            new()
+            {
+                Type = typeof(RootService),
+                Lifetime = Lifetime.Singleton,
+                AsTypes = [typeof(IRootService)],
+                RequiredTypes = [typeof(IDependency)],
+                AssemblyName = typeof(RootService).Assembly.GetName().Name ?? string.Empty,
+            },
+            new()
+            {
+                Type = typeof(Dependency),
+                Lifetime = Lifetime.Transient,
+                AsTypes = [typeof(IDependency)],
+                AssemblyName = typeof(Dependency).Assembly.GetName().Name ?? string.Empty,
+            },
+            new()
+            {
+                Type = typeof(UnusedService),
+                Lifetime = Lifetime.Transient,
+                AsTypes = [typeof(IUnusedService)],
+                AssemblyName = typeof(UnusedService).Assembly.GetName().Name ?? string.Empty,
+            },
+        };
+
+        return new QudiConfiguration { Registrations = registrations, Conditions = [] };
+    }
+
+    public interface IRootService;
+    public sealed class RootService(IDependency dependency) : IRootService;
+
+    public interface IDependency;
+    public sealed class Dependency : IDependency;
+
+    public interface IUnusedService;
+    public sealed class UnusedService : IUnusedService;
+}


### PR DESCRIPTION
### Motivation
- グラフ構築ロジックを Visualizer から Core 側へ移して、グラフ生成を再利用可能にし Visualizer は出力/レンダリングに専念させるため。 
- Core に移すことでユニットテストや他コンポーネントからの利用が容易になるため。 

### Description
- 移植: グラフ構築ロジック `QudiVisualizationGraphBuilder` を `Qudi.Visualizer` から `src/Qudi.Core/QudiVisualizationGraphBuilder.cs` に移し、API を `Qudi` 名前空間の public static クラスとして配置した。 
- モデル追加: グラフ型（`QudiVisualizationNode` / `QudiVisualizationEdge` / `QudiVisualizationGraph`）を `src/Qudi.Core/QudiVisualizationGraphModel.cs` として新規作成した。 
- Visualizer 側整理: `src/Qudi.Visualizer/QudiVisualizationModel.cs` からグラフ系の record 定義を削除し、`src/Qudi.Visualizer/GlobalUsings.cs` に `global using Qudi;` を追加して Core 型を参照するようにした。 
- テスト追加: `tests/Qudi.Tests/VisualizationGraphBuilderTests.cs` を追加し、`Build` と `BuildFromRoot` の挙動（登録エッジ／依存エッジの生成、ルート起点サブグラフの到達性）を検証するユニットテストを実装した。 

### Testing
- 追加したテストファイルは `tests/Qudi.Tests/VisualizationGraphBuilderTests.cs` で、`Build` と `BuildFromRoot` の振る舞いを検証するユニットテストを含む。 
- テスト実行コマンド `dotnet test tests/Qudi.Tests/Qudi.Tests.csproj --no-restore` を試行したが、実行環境に `dotnet` コマンドが存在しなかったため自動テストは実行できなかった。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991cc95a140832696104baed7818310)